### PR TITLE
feat: Update game controls and player spawn

### DIFF
--- a/js/scenes/GameScene.js
+++ b/js/scenes/GameScene.js
@@ -74,7 +74,7 @@ export default class GameScene extends Phaser.Scene {
             });
         });
 
-        this.player = new Player(this, 75, 150, this.character, this.characterTexture);
+        this.player = new Player(this, 75, 0, this.character, this.characterTexture);
         this.physics.add.collider(this.player, this.platforms);
         console.log('Player created:', this.player); // Debug log
 

--- a/js/utils/controls.js
+++ b/js/utils/controls.js
@@ -2,7 +2,7 @@ const controls = {
     left: ['LEFT', 'A'],
     right: ['RIGHT', 'D'],
     jump: ['SPACE', 'UP', 'W'],
-    power: ['CTRL', 'P'],
+    power: ['ControlLeft', 'P'],
     select: ['ENTER'],
     back: ['ESC']
 };


### PR DESCRIPTION
This commit addresses the user's request to update the game's controls and player spawn behavior.

- The player now spawns at the top of the level (y=0) to create a more noticeable "fall-in" effect.
- The power-up action is now specifically mapped to the Left Control key, in addition to the 'P' key.

The existing WASD and arrow key controls for movement and jump were already correctly configured and have been validated.