### PR TITLE
fix: Corregido el fallo de carga de la pantalla inicial

### DIFF
--- a/src/js/game.js
+++ b/src/js/game.js
@@ -8,7 +8,6 @@ const config = {
     type: Phaser.AUTO,
     width: 1024,
     height: 768,
-    parent: 'game-container', // Optional: if you have a div for the game
     pixelArt: true,
     zoom: 1, // Scale up the game - changed from 3 to 1 because of new resolution
     backgroundColor: '#1a1a1a',


### PR DESCRIPTION
El juego no se renderizaba porque la configuración de Phaser en `src/js/game.js` especificaba un `parent` con el id 'game-container', pero no existía ningún elemento con ese id en `src/index.html`.

Esto causaba que Phaser no pudiera adjuntar el canvas al DOM, impidiendo que el juego se mostrara.

La solución ha sido eliminar la propiedad `parent` de la configuración de Phaser, permitiendo que el canvas se adjunte directamente al `<body>` del documento.