### PR TITLE
feat: Ajustar el diseño visual para separar los controles

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -4,44 +4,38 @@ html, body {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    background-color: #000; /* Added from original body style */
+    background-color: #000;
 }
 
 body {
     display: flex;
-    justify-content: center;
-    align-items: center;
+    flex-direction: column; /* Organiza los hijos verticalmente */
 }
 
 #game-container {
-    width: 100vw;
-    height: 100vh;
+    flex: 1; /* Permite que el contenedor del juego crezca para llenar el espacio */
     display: flex;
     justify-content: center;
     align-items: center;
-    background-color: #333;
+    background-color: #000; /* Fondo negro para el área de juego */
+    overflow: hidden; /* Evita que el canvas se desborde */
 }
 
 canvas {
     max-width: 100%;
     max-height: 100%;
     object-fit: contain;
-    border: 2px solid #fff; /* Borde para visualización inicial */
 }
 
 #touch-controls {
-    position: fixed;
-    bottom: 20px;
-    width: 100%;
     display: flex;
     justify-content: space-between;
-    padding: 0 20px;
+    align-items: center;
+    width: 100%;
+    background-color: #000;
+    padding: 10px 20px;
     box-sizing: border-box;
-    pointer-events: none; /* Permite clicks 'a través' del contenedor principal */
-}
-
-.d-pad, .action-buttons {
-    pointer-events: auto; /* Reactiva los eventos para los botones */
+    height: 120px; /* Altura fija para la barra de control */
 }
 
 .control-button {

--- a/src/index.html
+++ b/src/index.html
@@ -5,10 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>Superiores: Escapando de la Prisión Inferior</title>
     <link rel="stylesheet" href="css/styles.css">
-    <style>
-        body { margin: 0; background-color: #000; }
-        canvas { display: block; margin: 0 auto; }
-    </style>
 </head>
 <body>
     <div id="game-container"></div>


### PR DESCRIPTION
Este commit refactoriza el diseño principal del juego para separar visualmente el lienzo del juego del área de controles táctiles.

- El diseño del cuerpo principal se cambia a una columna flexible.
- El contenedor del juego ahora llena el espacio disponible.
- Los controles táctiles se colocan en una barra negra de altura fija en la parte inferior de la pantalla.
- Los estilos en línea de index.html se han eliminado y centralizado en styles.css para un mejor mantenimiento.