### PR TITLE
Fix(player): Resolve player getting stuck and not moving

### DIFF
--- a/src/js/entities/Player.js
+++ b/src/js/entities/Player.js
@@ -14,6 +14,7 @@ export default class Player extends Phaser.Physics.Arcade.Sprite {
         scene.physics.add.existing(this);
 
         // Player physics properties
+        this.setOrigin(0.5, 1);
         this.setCollideWorldBounds(true);
         this.setBounce(0.1);
         this.body.setSize(32, 48);

--- a/src/js/scenes/GameScene.js
+++ b/src/js/scenes/GameScene.js
@@ -76,7 +76,7 @@ export default class GameScene extends Phaser.Scene {
         });
 
         const playerStartX = 100;
-        const playerStartY = (this.levelConfig.height - 4) * this.TILE_SIZE;
+        const playerStartY = (this.levelConfig.height - 2) * this.TILE_SIZE;
 
         this.player = new Player(this, playerStartX, playerStartY, this.character, this.characterTexture);
         this.physics.add.collider(this.player, this.platforms);


### PR DESCRIPTION
The player character was getting stuck in the ground due to a combination of its spawn position and physics body alignment. This was causing the physics engine to lock up, preventing any movement.

This commit addresses the issue by:
1. Setting the player's origin to (0.5, 1) to align the physics body with the sprite's feet.
2. Adjusting the player's initial Y-position to place it correctly on top of the ground.